### PR TITLE
Fix/breakpoints typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,21 +98,6 @@ Try the [examples](examples) on CodeSandbox
 ## Setup (React Native only)
 Style property values rely heavily on the concept of media breakpoints and responsive values (e.g. em, vh, vw), concepts that do not translate well to React Native.
 
-Unfortunately since TypeScript types from a library cannot be overriden safely the solution is to use patch-package.
-
-Here are the steps to fix your environment:
-
-1. Make sure patch-package is properly installed and configured, to know how check the [docs](https://github.com/ds300/patch-package).
-2. Open `node_modules/@tradersclub/styled-system/index.d.ts`
-3. Change the definition of `ResponsiveValue` removing the `| Partial<BreakpointsValue<T, ThemeType>>`, it should become something similar to this:   
-```TypeScript
-export type ResponsiveValue<T, ThemeType extends Theme = RequiredTheme> = T extends undefined | null
-  ? null
-  : T;
-```
-4. Save your changes by running `yarn patch-package`
-
-
 ## Usage
 
 ```jsx

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,17 +66,16 @@ export type BreakpointsValue<T, ThemeType extends Theme = RequiredTheme> = Recor
   T
 >;
 
-export type ResponsiveValue<T, ThemeType extends Theme = RequiredTheme> = T extends undefined | null
-  ? null
-  : T | Partial<BreakpointsValue<T, ThemeType>>;
+export type ResponsiveValue<T, ThemeType extends Theme = RequiredTheme> =
+  T | { [P in keyof ThemeType['breakpoints']]?: T };
 
 export type ThemeValue<
   K extends keyof CurrentTheme,
   CurrentTheme extends Theme
 > = CurrentTheme[K] extends TLengthStyledSystem[]
-  ? number
+  ? number | string
   : CurrentTheme[K] extends Record<infer E, TLengthStyledSystem>
-  ? E
+  ? E | ResponsiveValue<E, CurrentTheme>
   : CurrentTheme[K] extends ObjectOrArray<infer F>
   ? F
   : never;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tradersclub/styled-system",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "typings": "index.d.ts",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
- Fixes breakpoints not accepting a valid input such as the one below:

```js
{
    default: `m`,
    s: `s`,
}
```
Now properly accepting partial breakpoints.